### PR TITLE
Simplify the patching code _a lot_.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,38 +1,13 @@
-var methods = require("methods")
-  , Promise = require("bluebird")
-  , supertest = require("supertest");
+var Promise = require("bluebird");
 
-// Support SuperTest's historical `del` alias for `delete`
-methods.push("del");
+module.exports = require("supertest");
 
-function then(onFulfilled, onRejected) {
-  var end = Promise.promisify(this.end, this);
-  return end().then(onFulfilled, onRejected);
-}
+module.exports.Test.prototype.then = function() {
+  var promise = new Promise(function(resolve, reject) {
+    this.end(function(err, res) {
+      return err ? reject(err) : resolve(res);
+    });
+  }.bind(this));
 
-// Creates a new object that wraps `factory`, where each HTTP method (`get`,
-// `post`, etc.) is overriden to inject a `then` method into the returned `Test`
-// instance.
-function wrap(factory) {
-  var out = {};
-
-  methods.forEach(function (method) {
-    out[method] = function () {
-      var test = factory[method].apply(factory, arguments);
-      test.then = then;
-      return test;
-    };
-  });
-
-  return out;
-}
-
-module.exports = function () {
-  var request = supertest.apply(null, arguments);
-  return wrap(request);
-};
-
-module.exports.agent = function () {
-  var agent = supertest.agent.apply(null, arguments);
-  return wrap(agent);
+  return promise.then.apply(promise, arguments);
 };


### PR DESCRIPTION
Instead of wrapping each method, just inject a `.then` method into `supertest`'s `Test.prototype`.
