### PR TITLE
don't call both reject and resolve on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ function makeModule(Promise) {
       self.end(function (err, res) {
         if (err) {
           reject(err);
+        } else {
+          resolve(res);
         }
-        resolve(res);
       });
     });
   }


### PR DESCRIPTION
When end() calls the callback with an error, both the reject() and resolve() functions would be called.  Only one should be.