### PR TITLE
feat: add catch support to test methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ agent
 
 ### Promisey goodness
 
-To start, only the `then` method is exposed. But once you've called `.then`
-once, you've got a proper [Bluebird] promise that supports the whole gamut of
-promisey goodness:
+To start, only the `then` and `catch` methods are exposed. But once you've
+called `.then` or `.catch` once, you've got a proper [Bluebird] promise that
+supports the whole gamut of promisey goodness:
 
 ```js
 request(app)

--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ function makeModule(Promise) {
     return this.toPromise().then(onFulfilled, onRejected);
   }
 
+  function _catch(onRejected) {
+    var promise = this.toPromise();
+    return promise.catch.apply(promise, arguments);
+  }
+
   // Creates a new object that wraps `factory`, where each HTTP method
   // (`get`, `post`, etc.) is overriden to inject a `then` method into
   // the returned `Test` instance.
@@ -38,6 +43,7 @@ function makeModule(Promise) {
         var test = factory[method].apply(factory, arguments);
         test.toPromise = toPromise;
         test.then = then;
+        test.catch = _catch;
         return test;
       };
     });

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,14 @@ describe("supertestAsPromised", function () {
     it("should reject if an assertion fails", function () {
       return expect(agent.get("/home").expect(500)).to.eventually.be.rejected;
     });
+
+    it("should be able to catch failed promises", function() {
+        return agent.get("/home").expect(400).catch(function(err) {
+            return true;
+        }).then(function(caught) {
+            expect(caught).to.be.true;
+        });
+    });
   });
 });
 


### PR DESCRIPTION
Add a `catch` method so that failing tests can have additional actions added or so that ranges of expected status codes can be caught.

```js
request(app).get('/foo').expect(200).catch(() => { /* should fail with an unknown status code */ }
```

```js
request(app).get('/foo').expect(400).catch(err => { console.log('Something about the error'); throw err });
```

Or just as a convenient way to suppress a failing test.

```js
request(app).get('/foo').expect(200).catch(() => { /* suppressed because of issue#bar */ }
```