### PR TITLE
Return Response with Errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function makeModule(Promise) {
     return new Promise(function (resolve, reject) {
       self.end(function (err, res) {
         if (err) {
+          err.response = res;
           reject(err);
           return;
         }


### PR DESCRIPTION
Fix #30. For example, if expect(200) fails, we want to know why it
failed. With this change, we can do things like:

    .catch(function(err) {
        console.log(err.res.text);
        // ... Handle error ...
    });