### PR TITLE
add response to err object as a non-enumrable property

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ function makeModule(Promise) {
     return new Promise(function (resolve, reject) {
       self.end(function (err, res) {
         if (err) {
-          err.response = res;
+          Object.defineProperty(err, 'response', {
+            get: function () {
+              return res;
+            }
+          });
           reject(err);
           return;
         }


### PR DESCRIPTION
If an error raised by supertest ends up printed in stdout, the output is completely unreadable since response is quite a big object with a lot of properties. 